### PR TITLE
Move build configurations to separate files

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,33 +1,6 @@
-#### PROJECT SETTINGS ####
-# The name of the executable to be created
-BIN_NAME := hello
-# Compiler used
-CC ?= gcc
-# Extension of source files used in the project
-SRC_EXT = c
-# Path to the source directory, relative to the makefile
-SRC_PATH = .
-# Space-separated pkg-config libraries used by this project
-LIBS =
-# General compiler flags
-COMPILE_FLAGS = -std=c99 -Wall -Wextra -g
-# Additional release-specific flags
-RCOMPILE_FLAGS = -D NDEBUG
-# Additional debug-specific flags
-DCOMPILE_FLAGS = -D DEBUG
-# Add additional include paths
-INCLUDES = -I $(SRC_PATH)
-# General linker settings
-LINK_FLAGS =
-# Additional release-specific linker settings
-RLINK_FLAGS =
-# Additional debug-specific linker settings
-DLINK_FLAGS =
-# Destination directory, like a jail or mounted system
-DESTDIR = /
-# Install path (bin/ is appended automatically)
-INSTALL_PREFIX = usr/local
-#### END PROJECT SETTINGS ####
+# Project settings are
+# in vvv
+include config.mk
 
 # Generally should not need to edit below this line
 

--- a/c/config.mk
+++ b/c/config.mk
@@ -1,0 +1,30 @@
+#### PROJECT SETTINGS ####
+# The name of the executable to be created
+BIN_NAME := hello
+# Compiler used
+CC ?= gcc
+# Extension of source files used in the project
+SRC_EXT = c
+# Path to the source directory, relative to the makefile
+SRC_PATH = .
+# Space-separated pkg-config libraries used by this project
+LIBS =
+# General compiler flags
+COMPILE_FLAGS = -std=c99 -Wall -Wextra -g
+# Additional release-specific flags
+RCOMPILE_FLAGS = -D NDEBUG
+# Additional debug-specific flags
+DCOMPILE_FLAGS = -D DEBUG
+# Add additional include paths
+INCLUDES = -I $(SRC_PATH)
+# General linker settings
+LINK_FLAGS =
+# Additional release-specific linker settings
+RLINK_FLAGS =
+# Additional debug-specific linker settings
+DLINK_FLAGS =
+# Destination directory, like a jail or mounted system
+DESTDIR = /
+# Install path (bin/ is appended automatically)
+INSTALL_PREFIX = usr/local
+#### END PROJECT SETTINGS ####

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,33 +1,6 @@
-#### PROJECT SETTINGS ####
-# The name of the executable to be created
-BIN_NAME := hello
-# Compiler used
-CXX ?= g++
-# Extension of source files used in the project
-SRC_EXT = cpp
-# Path to the source directory, relative to the makefile
-SRC_PATH = .
-# Space-separated pkg-config libraries used by this project
-LIBS =
-# General compiler flags
-COMPILE_FLAGS = -std=c++11 -Wall -Wextra -g
-# Additional release-specific flags
-RCOMPILE_FLAGS = -D NDEBUG
-# Additional debug-specific flags
-DCOMPILE_FLAGS = -D DEBUG
-# Add additional include paths
-INCLUDES = -I $(SRC_PATH)
-# General linker settings
-LINK_FLAGS =
-# Additional release-specific linker settings
-RLINK_FLAGS =
-# Additional debug-specific linker settings
-DLINK_FLAGS =
-# Destination directory, like a jail or mounted system
-DESTDIR = /
-# Install path (bin/ is appended automatically)
-INSTALL_PREFIX = usr/local
-#### END PROJECT SETTINGS ####
+# Project settings are
+# in vvv
+include config.mk
 
 # Generally should not need to edit below this line
 

--- a/cpp/config.mk
+++ b/cpp/config.mk
@@ -1,0 +1,31 @@
+#### PROJECT SETTINGS ####
+
+# The name of the executable to be created
+BIN_NAME := hello
+# Compiler used
+CXX ?= g++
+# Extension of source files used in the project
+SRC_EXT = cpp
+# Path to the source directory, relative to the makefile
+SRC_PATH = .
+# Space-separated pkg-config libraries used by this project
+LIBS =
+# General compiler flags
+COMPILE_FLAGS = -std=c++11 -Wall -Wextra -g
+# Additional release-specific flags
+RCOMPILE_FLAGS = -D NDEBUG
+# Additional debug-specific flags
+DCOMPILE_FLAGS = -D DEBUG
+# Add additional include paths
+INCLUDES = -I $(SRC_PATH)
+# General linker settings
+LINK_FLAGS =
+# Additional release-specific linker settings
+RLINK_FLAGS =
+# Additional debug-specific linker settings
+DLINK_FLAGS =
+# Destination directory, like a jail or mounted system
+DESTDIR = /
+# Install path (bin/ is appended automatically)
+INSTALL_PREFIX = usr/local
+#### END PROJECT SETTINGS ####


### PR DESCRIPTION
In my own makefiles I try to separate the configuration and the commands/build targets etc.

I think moving settings from the makefiles here would make the whole thing a bit more elegant. And also any improvements could be merged into the projects using this one without checking settings by hand.